### PR TITLE
Version 0.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,12 @@ TODO: mere beskrivelse
 
 Se [DKFDS-Vue3 Demo](https://whitewillow.github.io/dkfds-vue3-example) (Stadig under udarbejdelse)
 
-# Brug det:
 
-> **INFO**: dkfds-vue3 har pt en bug med ren vite projekt - fix på vej. 
-> Dvs. brug gl måde at oprette vue projekt `vue create hello-world` indtil videre
+<br />
+<br />
 
-**Designsystem**
+# Installation:
 
-Indtil videre forventes designssystemets egen komponent er installeret:
-
-
-```
-npm install --save dkfds
-```
-
-```typescript
-// src/global.d.ts
-declare module 'dkfds';
-```
-
-**dkfds-vue3**
 
 ```
 npm install -S dkfds-vue3
@@ -72,20 +58,10 @@ createApp(App)
 ```html
 // app.ts
 <template>
+  ...
   <fds-icon-collection />
   <!-- Sørger for at ikoner bliver indlæst -->
-  ...
 </template>
-<script lang="ts">
-  import { defineComponent } from "vue";
-  import DKFDS from "dkfds";
-
-  DKFDS.init();
-
-  export default defineComponent({
-    name: "App",
-  });
-</script>
 
 <style lang="scss">
   $font-path: "~dkfds/src/fonts/IBMPlexSans/";
@@ -97,9 +73,14 @@ createApp(App)
 </style>
 ```
 
+
 eller se [app.vue eksempel](./dokumentation/app-vue-example.md)
 
 
+For Borger DK tema brug følgende istedet for `dkfds-virkdk`
+```html
+@import '../node_modules/dkfds/src/stylesheets/dkfds-borgerdk.scss';
+```
 # Se det / Example Project
 
 Bedste måde at se hvad der er muligt er at køre example projektet, indtil der kommer noget rigtig dokumentation.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,20 +8,27 @@ Mangler
 - FileList
 
 TODO:
-Refak xfds inputs - split val ud
-overvej om magi med fejl og validering
-xfds-form-xx - fjern validering
-xfds-form-val-xx - har validering
-repeat code xfds input filer
-Fælles watcher
+- Refak xfds inputs - split val ud
+- overvej om magi med fejl og validering
+- xfds-form-xx - fjern validering
+- xfds-form-val-xx - har validering
+- repeat code xfds input filer
+- Fælles watcher
 
 # 0.3.6
-WIP
+
 - Refak af tooltip
 - Refak af dropdown
+- Ændret installations process.
 
-Et skridt mod at løse fejlen https://github.com/whitewillow/dkfds-vue3/issues/7
+Ovenstående løser fejl med brug af rent Vite project. https://github.com/whitewillow/dkfds-vue3/issues/7
 
+Dvs. det er nu muligt at oprette et nyt projekt:
+
+```
+npm create vue@3
+```
+Og gennemføre alm. installation process for DKFDS-Vue3
 
 
 # 0.3.5

--- a/dokumentation/WIP.md
+++ b/dokumentation/WIP.md
@@ -51,6 +51,22 @@ Eksempel:
 </fds-formgroup>
 ```
 
+## 0.3.6 - :heavy_check_mark:
+
+- Refak af tooltip
+- Refak af dropdown
+- Ændret installations process.
+
+Ovenstående løser fejl med brug af rent Vite project. https://github.com/whitewillow/dkfds-vue3/issues/7
+
+Dvs. det er nu muligt at oprette et nyt projekt:
+
+```
+npm create vue@3
+```
+Og gennemføre alm. installation process for DKFDS-Vue3
+
+
 ## v0.4 - igang
 - Alle komponenter er lavet, undtagen:
   - Skip link

--- a/dokumentation/app-vue-example.md
+++ b/dokumentation/app-vue-example.md
@@ -297,10 +297,8 @@ Nedestående er et eksempel på `app.vue`
 </template>
 
 <script setup lang="ts">
-import DKFDS from 'dkfds';
 import { useRoute, useRouter } from 'vue-router';
 
-DKFDS.init();
 const route = useRoute();
 const router = useRouter();
 const isPartOfMenu = (name: string): boolean => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -121,7 +121,7 @@ $font-path: '~dkfds/src/fonts/IBMPlexSans/';
 $image-path: '~dkfds/src/img';
 $site-image-path: '~dkfds/src/img';
 $icons-folder-path: '~dkfds/src/img/svg-icons';
-@import '../node_modules/dkfds/src/stylesheets/dkfds-virkdk';
+@import '../node_modules/dkfds/src/stylesheets/dkfds-borgerdk.scss';
 @import 'assets/bgs.scss';
 @import 'assets/main.scss';
 </style>


### PR DESCRIPTION
## 0.3.6 - :heavy_check_mark:

- Refak af tooltip
- Refak af dropdown
- Ændret installations process.

Ovenstående løser fejl med brug af rent Vite project. https://github.com/whitewillow/dkfds-vue3/issues/7

Dvs. det er nu muligt at oprette et nyt projekt:

```
npm create vue@3
```
Og gennemføre alm. installation process for DKFDS-Vue3