### PR TITLE
20 xfds validate

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,16 +4,38 @@
 
 https://github.com/whitewillow/dkfds-vue3/issues
 
-Mangler
-- FileList
 
-TODO:
-- Refak xfds inputs - split val ud
-- overvej om magi med fejl og validering
-- xfds-form-xx - fjern validering
-- xfds-form-val-xx - har validering
-- repeat code xfds input filer
-- Fælles watcher
+# 0.3.7
+
+- Refak af xfds-validate
+- Refak af xfds form komponenter
+
+Validering er udskilt fra xfds form komponenter, dvs den skal kaldes seperat:
+
+```
+<xfds-validate :modelValue="user.adress" :validations="[hasContent, charactersMinLength(10)]">
+  <xfds-form-input
+    label="Adresse"
+    hint="Angiv gyldig adresse"
+    tooltip="Input tooltip"
+    input-type="street-address"
+    autocomplete="street-address"
+    placeholder="e.g: Jarlsvej 23"
+    v-model="user.adress"
+  />
+</xfds-validate>
+
+// eller
+
+<xfds-validate :modelValue="user.name" :validations="[hasContent, charactersMinLength(10)]">
+  <fds-input v-model="user.name" />
+</xfds-validate>
+```
+
+Som udgangspunkt vil xfds-validate selv prøve at lytte på `input|select` `blur` og begynde at validere herefter, man kan også slå dette fra `useAutoDirty=false` og selv angive `dirty`.
+
+
+
 
 # 0.3.6
 

--- a/dokumentation/Overvejelser.md
+++ b/dokumentation/Overvejelser.md
@@ -26,44 +26,6 @@ Gå til Forside
 </fds-link>
 ```
 
-## Manuel tilgang - venstremenu og trin
-
-Overvej at, også, tilbyde en mere manuel tilgang til hhv venstremenu og trin m.fl.
-Istedet for at give en liste med, give muligfor at direkte at skrive sit "a" tag.
-
-```html
-
-<fds-trinindikator
-        @navigate="trinNavKey = $event">
-        
-  <template v-slot:[`0`]> 
-    <a href='#' role='menuitem'>
-      <span class='sidenav-number'>1.</span>
-      <span class='sidenav-title'>Lorem ipsum</span>
-      <span class='sidenav-icon'>
-        <svg class='icon-svg' aria-hidden='true' focusable='false' tabindex='-1'>
-          <use xlink:href='#done'></use>
-        </svg>
-      </span>
-    </a>
-  </template>
-  <template v-slot:[`1`]> 
-    <a href='#' role='menuitem'>
-      <span class='sidenav-number'>2.</span>
-      <span class='sidenav-title'>Lorem ipsum</span>
-      <span class='sidenav-icon'>
-        <svg class='icon-svg' aria-hidden='true' focusable='false' tabindex='-1'>
-          <use xlink:href='#done'></use>
-        </svg>
-      </span>
-    </a>
-  </template>
-</fds-trinindikator>
-
-```
-
-
-
 ## Layout
 Forslag til hvordan layout/implementering kunne laves?
 
@@ -101,4 +63,4 @@ Forslag til hvordan layout/implementering kunne laves?
     </fds-footer>
     <fds-cookies />
 <fds>
-
+```

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "core-js": "^3.8.3",
     "dkfds": "^8.2.0",
-    "dkfds-vue3": "0.3.6",
+    "dkfds-vue3": "0.3.7",
     "vue": "^3.2.39",
     "vue-router": "^4.0.3",
     "vuex": "^4.0.0"

--- a/example/src/views/EkstraKomponenter/DropdownMenu.vue
+++ b/example/src/views/EkstraKomponenter/DropdownMenu.vue
@@ -16,12 +16,13 @@
     </fds-component-preview>
 
     <fds-component-preview header="Eksempel Formular">
-      <xfds-form-dropdown
-        label="Dropdown form"
-        :validations="[hasContent]"
-        :options="dropdownOptions"
-        v-model="dropdownValForm"
-      />
+      <xfds-validate :modelValue="dropdownValForm" :validations="[hasContent]">
+        <xfds-form-dropdown
+          label="Dropdown form"
+          :options="dropdownOptions"
+          v-model="dropdownValForm"
+        />
+      </xfds-validate>
 
       <fds-pre header="v-model for dropdown" :json="{ dropdownValForm }" />
 

--- a/example/src/views/EkstraKomponenter/FormGroup.vue
+++ b/example/src/views/EkstraKomponenter/FormGroup.vue
@@ -16,6 +16,13 @@
           <code>xfds-form-group</code> giver dig let adgang til label, hint tooltip, tooltip,
           fejlmeddelelse som alle også har tilhørende templates
         </p>
+
+        <p>
+          Samme provide og inject som
+          <router-link :to="{ name: 'komponentformgruppe' }"> Formgruppe </router-link> og
+
+          <router-link :to="{ name: 'komponentfejlmeddelelser' }"> Fejlmeddelelse </router-link>
+        </p>
       </template>
       <template #code>
         <pre v-text="code"></pre>
@@ -51,6 +58,15 @@ const code = `
 <xfds-form-group label="Bil mærke" hint="Angiv et mærke" tooltip="Hjælp i tooltip">
   <fds-input v-model="maerke" />
 </xfds-form-group>
+
+// Eller
+
+<xfds-form-group hint="Angiv et mærke" tooltip="Hjælp i tooltip">
+  <template #label>
+    <fds-label>Bil mærke</fds-label>
+  </template>
+  <fds-input v-model="maerke" />
+</xfds-form-group>
 `;
 const code2 = `
 <xfds-form-group label="Farver" hint="Angiv et alle farver" tooltip="Hjælp i tooltip">
@@ -59,5 +75,6 @@ const code2 = `
   </template>
   <fds-textarea v-model="farver" />
 </xfds-form-group>
+
 `;
 </script>

--- a/example/src/views/EkstraKomponenter/FormValidering.vue
+++ b/example/src/views/EkstraKomponenter/FormValidering.vue
@@ -19,34 +19,78 @@
 
       <fds-pre header="object data" :json="user" />
 
-      <h2>Validering komponent</h2>
-      <div class="col-10">
-        <fds-strukturerede-liste header="modelValue">
-          <template #header>
-            <fds-label class="d-block">modelValue</fds-label>
-            <code>string, number, array</code>
-          </template>
-          tager imod <code>string, number, array</code>
-        </fds-strukturerede-liste>
-        <fds-strukturerede-liste header="validations">
-          <template #header>
-            <fds-label class="d-block">validations</fds-label>
-            <code>Array'&lt;'(x?: unknown) => string | null'&gt;'</code>
-          </template>
-          et array af valideringsmetoder
-        </fds-strukturerede-liste>
-        <fds-strukturerede-liste header="dirty">
-          <template #header>
-            <fds-label class="d-block">dirty</fds-label>
-            <code>Boolean</code>
-          </template>
-          Om feltet er blevet berørt
-        </fds-strukturerede-liste>
-        <fds-strukturerede-liste header='#default="{ isValid, errorMessage }"'>
-          Eksponering af resultatet, om modelValue er validt <code>isValid</code> og evt. tilhørende
-          fejlbesked <code>errorMessage</code>
-        </fds-strukturerede-liste>
-      </div>
+      <p class="h4">Props</p>
+      <table class="table table--compact">
+        <thead>
+          <tr>
+            <th></th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Beskrivelse</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>modelValue</code></td>
+            <td><code>string, number, array</code></td>
+            <td><code>null</code></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><code>validations</code></td>
+            <td><code>Array'&lt;'(x?: unknown) => string | null'&gt;'</code></td>
+            <td>
+              <code>
+                [(input: unknown) => { if (!input) { return 'Indtast data'; } return null; }]</code
+              >
+            </td>
+            <td>Et array af valideringsmetoder</td>
+          </tr>
+          <tr>
+            <td><code>dirty</code></td>
+            <td><code>boolean</code></td>
+            <td><code>false</code></td>
+            <td>Om feltet er blevet berørt</td>
+          </tr>
+          <tr>
+            <td><code>useAutoDirty</code></td>
+            <td><code>boolean</code></td>
+            <td><code>true</code></td>
+            <td>Om underliggende input eller select felt er blevet berørt (blur event)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="h4">Provide</p>
+      <table class="table table--compact">
+        <thead>
+          <tr>
+            <th></th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Beskrivelse</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>provideIsValid</code></td>
+            <td><code>boolean</code></td>
+            <td><code>true</code></td>
+            <td>Er alle validations valide</td>
+          </tr>
+          <tr>
+            <td><code>provideErrorMessage</code></td>
+            <td><code>string</code></td>
+            <td>
+              <code> ''</code>
+            </td>
+            <td>Først fundne fejl</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>Det er også muligt at brug slot props, <code>#default="{ isValid, errorMessage }</code></p>
+
       <fds-pre header="properties" :code="codeValidate" />
 
       <h2>Validerings metoder</h2>
@@ -106,6 +150,20 @@ const codeValidate = `
     #default="{ isValid, errorMessage }"
   >
   ...
+  </xfds-validate>
+
+
+  // Eller
+
+  <xfds-validate
+    :modelValue="user.name"
+    :validations="[hasContent, charactersMinLength(10)]">
+    <fds-formgroup> // lytter efter provideIsValid
+      <fds-label> Navn </fds-label>
+      <fds-fejlmeddelelse /> // lytter efter provideErrorMessage
+      <fds-hint>Indtast navn</fds-hint>
+      <fds-input v-model="user.name" />
+    </fds-formgroup>
   </xfds-validate>
   `;
 

--- a/example/src/views/EkstraKomponenter/NummerFelt.vue
+++ b/example/src/views/EkstraKomponenter/NummerFelt.vue
@@ -7,14 +7,15 @@
         v-model="lager.lager"
       />
 
-      <xfds-form-input-number
-        label="Forventet lager"
-        hint="Angiv gyldig lager antal"
-        tooltip="Input tooltip"
-        prefix="stk."
-        v-model="lager.forventetLager"
-        :validations="[numberMin(2)]"
-      />
+      <xfds-validate :modelValue="lager.forventetLager" :validations="[numberMin(2)]">
+        <xfds-form-input-number
+          label="Forventet lager"
+          hint="Angiv gyldig lager antal"
+          tooltip="Input tooltip"
+          prefix="stk."
+          v-model="lager.forventetLager"
+        />
+      </xfds-validate>
 
       <xfds-form-input-number
         inputClass="input-width-xs"
@@ -55,14 +56,15 @@ const code = `
   v-model="lager.lager"
 />
 
-<xfds-form-input-number
-  label="Forventet lager"
-  hint="Angiv gyldig lager antal"
-  tooltip="Input tooltip"
-  prefix="stk."
-  v-model="lager.forventetLager"
-  :validations="[numberMin(2)]"
-/>
+<xfds-validate :modelValue="lager.forventetLager" :validations="[numberMin(2)]">
+  <xfds-form-input-number
+    label="Forventet lager"
+    hint="Angiv gyldig lager antal"
+    tooltip="Input tooltip"
+    prefix="stk."
+    v-model="lager.forventetLager"
+  />
+</xfds-validate>
 
 <xfds-form-input-number
   inputClass="input-width-xs"

--- a/example/src/views/EkstraKomponenter/TekstFelt.vue
+++ b/example/src/views/EkstraKomponenter/TekstFelt.vue
@@ -3,16 +3,17 @@
     <fds-component-preview header="Tekstfelter">
       <xfds-form-input label="Navn" placeholder="e.g: Anders Hansen" v-model="user.name" />
 
-      <xfds-form-input
-        label="Adresse"
-        hint="Angiv gyldig adresse"
-        tooltip="Input tooltip"
-        input-type="street-address"
-        autocomplete="street-address"
-        placeholder="e.g: Jarlsvej 23"
-        v-model="user.adress"
-        :validations="[hasContent, charactersMinLength(10)]"
-      />
+      <xfds-validate :modelValue="user.adress" :validations="[hasContent, charactersMinLength(10)]">
+        <xfds-form-input
+          label="Adresse"
+          hint="Angiv gyldig adresse"
+          tooltip="Input tooltip"
+          input-type="street-address"
+          autocomplete="street-address"
+          placeholder="e.g: Jarlsvej 23"
+          v-model="user.adress"
+        />
+      </xfds-validate>
 
       <xfds-form-input
         inputClass="input-width-xs"
@@ -61,16 +62,17 @@ const user = ref({
 const code = `
 <xfds-form-input label="Navn" placeholder="e.g: Anders Hansen" v-model="user.name" />
 
-<xfds-form-input
-  label="Adresse"
-  hint="Angiv gyldig adresse"
-  tooltip="Input tooltip"
-  input-type="street-address"
-  autocomplete="street-address"
-  placeholder="e.g: Jarlsvej 23"
-  v-model="user.adress"
-  :validations="[hasContent, charactersMinLength(10)]"
-/>
+<xfds-validate :modelValue="user.adress" :validations="[hasContent, charactersMinLength(10)]">
+  <xfds-form-input
+    label="Adresse"
+    hint="Angiv gyldig adresse"
+    tooltip="Input tooltip"
+    input-type="street-address"
+    autocomplete="street-address"
+    placeholder="e.g: Jarlsvej 23"
+    v-model="user.adress"
+  />
+</xfds-validate>
 
 <xfds-form-input
   inputClass="input-width-xs"

--- a/example/src/views/EkstraKomponenter/TekstOmraade.vue
+++ b/example/src/views/EkstraKomponenter/TekstOmraade.vue
@@ -1,13 +1,17 @@
 <template>
   <section>
     <fds-component-preview header="Eksempel">
-      <xfds-form-textarea
-        label="Beskrivelse"
-        hint="Angiv beskrivelse af produktet"
-        placeholder="...Produktet er består af xxx"
-        v-model="product.beskrivelse"
+      <xfds-validate
+        :modelValue="product.beskrivelse"
         :validations="[hasContent, charactersMinLength(10)]"
-      />
+      >
+        <xfds-form-textarea
+          label="Beskrivelse"
+          hint="Angiv beskrivelse af produktet"
+          placeholder="...Produktet er består af xxx"
+          v-model="product.beskrivelse"
+        />
+      </xfds-validate>
 
       <fds-pre header="v-model" :json="product" />
 

--- a/example/src/views/EkstraKomponenter/TjekboksListe.vue
+++ b/example/src/views/EkstraKomponenter/TjekboksListe.vue
@@ -28,11 +28,9 @@
     <hr class="my-6" />
 
     <fds-component-preview header="Eksempel Formular">
-      <xfds-form-checkbox-list
-        label="Checkbox form"
-        :validations="[arrayHasItems]"
-        v-model="checkboxListForm"
-      />
+      <xfds-validate :modelValue="checkboxListForm" :validations="[arrayHasItems]">
+        <xfds-form-checkbox-list label="Checkbox form" v-model="checkboxListForm" />
+      </xfds-validate>
 
       <fds-pre header="v-model for checkbox liste" :json="checkboxListForm" />
 
@@ -41,7 +39,6 @@
           Komponenten <code>xfds-form-checkbox-list</code> er en samling af komponenter der giver en
           samlet funktionalitet.
         </p>
-        <p class="italic">Understøtter simpel validering, m.m.</p>
       </template>
       <template #code>
         <pre v-text="code"></pre>
@@ -91,11 +88,9 @@ const checkboxList = ref<FdsCheckboxItem[]>([
 ]);
 
 const code = `
-  <xfds-form-checkbox-list
-    label="Checkbox form"
-    :validations="[arrayHasItems]"
-    v-model="checkboxListForm"
-  />
+  <xfds-validate :modelValue="checkboxListForm" :validations="[arrayHasItems]">
+    <xfds-form-checkbox-list label="Checkbox form" v-model="checkboxListForm" />
+  </xfds-validate>
   
   const checkboxListForm = ref<FdsCheckboxItem[]>([
     {

--- a/example/src/views/Komponenter/FejlmeddelelserExample.vue
+++ b/example/src/views/Komponenter/FejlmeddelelserExample.vue
@@ -14,6 +14,24 @@
           Udskrive fejlmeddelelse med <code>fds-fejlmeddelelse</code> hertil skal form gruppen og
           vide at der er Fejl. Dette gøre med <code>:is-valid</code>
         </p>
+
+        <p class="h4">Inject</p>
+        <table class="table table--compact">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Type</th>
+              <th>Beskrivelse</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>provideErrorMessage</code></td>
+              <td><code>string</code></td>
+              <td>lytter efter provideErrorMessage og sættes som default indhold i slot</td>
+            </tr>
+          </tbody>
+        </table>
       </template>
       <template #code>
         <pre v-text="code"></pre>

--- a/example/src/views/Komponenter/FormgruppeExample.vue
+++ b/example/src/views/Komponenter/FormgruppeExample.vue
@@ -15,13 +15,72 @@
           Komponenten <code>fds-formgroup</code> er et wrapper komponent, der omfavner input,
           labels, m.fl elementer - se koden
         </p>
+
+        <p class="h4">Props</p>
+        <table class="table table--compact">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Type</th>
+              <th>Default</th>
+              <th>Beskrivelse</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>isValid</code></td>
+              <td><code>boolean</code></td>
+              <td><code>true</code></td>
+              <td>Hvis false sættes class form-error</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="h4">Provide</p>
+        <table class="table table--compact">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Type</th>
+              <th>Default</th>
+              <th>Beskrivelse</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>formid</code></td>
+              <td><code>string</code></td>
+              <td><code>Auto id</code></td>
+              <td>Udstiller form id</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="h4">Inject</p>
+        <table class="table table--compact">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Type</th>
+              <th>Beskrivelse</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>provideIsValid</code></td>
+              <td><code>boolean</code></td>
+              <td>lytter efter provideIsValid, vægtes højere end props.isValid</td>
+            </tr>
+          </tbody>
+        </table>
+
         <p class="italic">
           Komponenten udstiller(provide) et <code>formid</code> som <code>fds-label</code> selv
           omdanner til <code>for</code> id og <code>fds-[input]</code> elementer benytter som
           <code>id</code>
         </p>
         <p class="italic">
-          hvis nødvendigt kan man selv bruge enten
+          Hvis nødvendigt kan man selv bruge enten
           <code> &lt;fds-formgroup #default="{ formid }" &gt; </code>
           eller selv <code>const formid = inject('formid', null)</code>
         </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkfds-vue3",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "dist/dkfds-vue3.esm.js",
   "types": "dist/main.d.ts",
   "repository": {

--- a/src/components/extra/xfds-checkbox-list.vue
+++ b/src/components/extra/xfds-checkbox-list.vue
@@ -1,20 +1,20 @@
 <template>
   <ul
     class="nobullet-list"
-    :id="formId">
+    :id="formid">
     <li
       v-for="(checkbox, index) of value"
       :key="index">
       <input
-        :id="'checkbox-' + formId + '-' + index"
+        :id="'checkbox-' + formid + '-' + index"
         type="checkbox"
-        :name="'checkbox' + formId"
+        :name="'checkbox' + formid"
         v-model="checkbox.checked"
         :disabled="checkbox.disabled"
         @change="handleInput"
         @blur="handleDirty"
         class="form-checkbox checkbox-large"/>
-      <label :for="'checkbox-' + formId + '-' + index">
+      <label :for="'checkbox-' + formid + '-' + index">
         {{ checkbox.title }}
       </label>
 
@@ -30,11 +30,9 @@
 </template>
 
 <script setup lang="ts">
-import {
-  defineProps, defineEmits, ref, computed,
-} from 'vue';
-import { v4 as uuidv4 } from 'uuid';
+import { defineProps, defineEmits, ref } from 'vue';
 import fdsCheckboxProps from '@/props/fds-checkbox.props';
+import getFormId from '@/composable/formId';
 
 const props = defineProps({
   ...fdsCheckboxProps,
@@ -56,7 +54,7 @@ const handleInput = () => {
   emit('update:modelValue', value.value);
 };
 
-const formId = computed(() => uuidv4());
+const { formid } = getFormId(props.id, true);
 </script>
 
 <style scoped lang="scss"></style>

--- a/src/components/extra/xfds-dropdown.vue
+++ b/src/components/extra/xfds-dropdown.vue
@@ -1,15 +1,16 @@
 <template>
   <select
     class="form-select"
+    :class="{ dirty: dirty }"
     :disabled="isDisabled"
     :name="formid"
     :id="formid"
     v-bind="refValue"
     @change="onInput"
-    @blur="$emit('dirty', true)">
+    @blur="onDirty">
     <option
       :value="refValue"
-      v-if="!optionHeader">
+      v-if="optionHeader">
       {{ optionHeader }}
     </option>
     <option
@@ -65,6 +66,11 @@ const emit = defineEmits(['update:modelValue', 'dirty', 'change']);
 const refValue = ref(props.modelValue);
 const { formid } = getFormId(props.id, true);
 
+const dirty = ref(false);
+const onDirty = () => {
+  dirty.value = true;
+  emit('dirty', true);
+};
 const onInput = (event: Event) => emit('update:modelValue', (event?.target as HTMLInputElement).value);
 </script>
 

--- a/src/components/extra/xfds-form-checkbox-list.vue
+++ b/src/components/extra/xfds-form-checkbox-list.vue
@@ -1,35 +1,28 @@
 <template>
-  <xfds-validate
-    :modelValue="value"
-    :validations="validations"
-    #default="{ isValid, errorMessage }"
-    :dirty="dirty"
-    @valid="validEvent">
-    <xfds-form-group
-      v-bind="{
-        label,
-        hint,
-        tooltip,
-        isValid,
-        errorMessage,
-      }">
-      <xfds-checkbox-list
-        v-model="value"
-        @dirty="touchedEvent"
-        @update:modelValue="handleInput">
-        <slot />
-      </xfds-checkbox-list>
-    </xfds-form-group>
-  </xfds-validate>
+  <xfds-form-group
+    v-bind="{
+      label,
+      hint,
+      tooltip,
+      isValid,
+      errorMessage,
+    }">
+    <xfds-checkbox-list
+      v-model="value"
+      @dirty="touchedEvent"
+      @update:modelValue="handleInput">
+      <slot />
+    </xfds-checkbox-list>
+  </xfds-form-group>
 </template>
 
 <script setup lang="ts">
 import {
   defineEmits, defineProps, ref, watch,
 } from 'vue';
+import { FdsCheckboxItem } from '@/model/fds.model';
 
 import fdsCheckboxProps from '@/props/fds-checkbox.props';
-import { FdsCheckboxItem } from '@/model/fds.model';
 import xfdsFormGroupProps from '@/props/fds-form.props';
 
 const props = defineProps({
@@ -51,10 +44,6 @@ const dirty = ref(false);
 
 const touchedEvent = () => {
   dirty.value = true;
-};
-
-const validEvent = (isValid: boolean) => {
-  emit('valid', isValid);
 };
 
 const handleInput = (event: Array<FdsCheckboxItem>) => {

--- a/src/components/extra/xfds-form-dropdown.vue
+++ b/src/components/extra/xfds-form-dropdown.vue
@@ -42,6 +42,7 @@ const dirty = ref(false);
 
 const touchedEvent = () => {
   dirty.value = true;
+  emit('dirty', true);
 };
 
 const handleInput = () => emit('update:modelValue', value.value);

--- a/src/components/extra/xfds-form-dropdown.vue
+++ b/src/components/extra/xfds-form-dropdown.vue
@@ -1,34 +1,27 @@
 <template>
-  <xfds-validate
-    :modelValue="value"
-    :validations="validations"
-    #default="{ isValid, errorMessage }"
-    :dirty="dirty"
-    @valid="validEvent">
-    <xfds-form-group
-      v-bind="{
-        label,
-        hint,
-        tooltip,
-        isValid,
-        errorMessage,
-      }">
-      <xfds-dropdown
-        :options="options"
-        v-model="value"
-        @update:modelValue="handleInput"
-        @dirty="touchedEvent"/>
-    </xfds-form-group>
-  </xfds-validate>
+  <xfds-form-group
+    v-bind="{
+      label,
+      hint,
+      tooltip,
+      isValid,
+      errorMessage,
+    }">
+    <xfds-dropdown
+      :options="options"
+      v-model="value"
+      @update:modelValue="handleInput"
+      @dirty="touchedEvent"/>
+  </xfds-form-group>
 </template>
 
 <script setup lang="ts">
 import {
   defineEmits, defineProps, PropType, ref, watch,
 } from 'vue';
-import xfdsFormGroupProps from '@/props/fds-form.props';
-import fdsInputProps from '@/props/fds-input.props';
 import { FdsOptionItem } from '@/model/fds.model';
+import fdsInputProps from '@/props/fds-input.props';
+import xfdsFormGroupProps from '@/props/fds-form.props';
 
 const props = defineProps({
   ...fdsInputProps,
@@ -49,10 +42,6 @@ const dirty = ref(false);
 
 const touchedEvent = () => {
   dirty.value = true;
-};
-
-const validEvent = (isValid: boolean) => {
-  emit('valid', isValid);
 };
 
 const handleInput = () => emit('update:modelValue', value.value);

--- a/src/components/extra/xfds-form-group.vue
+++ b/src/components/extra/xfds-form-group.vue
@@ -1,5 +1,5 @@
 <template>
-  <fds-formgroup :is-valid="isValid">
+  <fds-formgroup :is-valid="compValid">
     <slot name="label">
       <fds-label v-if="label">
         {{ label }}
@@ -14,8 +14,8 @@
     </slot>
 
     <slot name="fejlmeddelelse">
-      <fds-fejlmeddelelse v-if="!isValid">
-        {{ errorMessage }}
+      <fds-fejlmeddelelse v-if="!compValid">
+        {{ compErrorMessage }}
       </fds-fejlmeddelelse>
     </slot>
     <slot name="hint">
@@ -26,11 +26,19 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import {
+  computed, defineProps, inject, ref,
+} from 'vue';
 
 import xfdsFormGroupProps from '@/props/fds-form.props';
 
-defineProps({
+const props = defineProps({
   ...xfdsFormGroupProps,
 });
+
+const injIsValid = ref<boolean | null>(inject('validateIsValid', null));
+const injErrorMessage = ref<string | null>(inject('validateErrorMessage', null));
+
+const compValid = computed(() => injIsValid.value ?? props.isValid);
+const compErrorMessage = computed(() => injErrorMessage.value ?? props.errorMessage);
 </script>

--- a/src/components/extra/xfds-form-group.vue
+++ b/src/components/extra/xfds-form-group.vue
@@ -36,8 +36,8 @@ const props = defineProps({
   ...xfdsFormGroupProps,
 });
 
-const injIsValid = ref<boolean | null>(inject('validateIsValid', null));
-const injErrorMessage = ref<string | null>(inject('validateErrorMessage', null));
+const injIsValid = ref<boolean | null>(inject('provideIsValid', null));
+const injErrorMessage = ref<string | null>(inject('provideErrorMessage', null));
 
 const compValid = computed(() => injIsValid.value ?? props.isValid);
 const compErrorMessage = computed(() => injErrorMessage.value ?? props.errorMessage);

--- a/src/components/extra/xfds-form-input-number.vue
+++ b/src/components/extra/xfds-form-input-number.vue
@@ -1,34 +1,27 @@
 <template>
-  <xfds-validate
-    :modelValue="value"
-    :validations="validations"
-    #default="{ isValid, errorMessage }"
-    :dirty="dirty"
-    @valid="validEvent">
-    <xfds-form-group
+  <xfds-form-group
+    v-bind="{
+      label,
+      hint,
+      tooltip,
+      isValid,
+      errorMessage,
+    }">
+    <fds-input-number
+      v-model="value"
       v-bind="{
-        label,
-        hint,
-        tooltip,
-        isValid,
-        errorMessage,
-      }">
-      <fds-input-number
-        v-model="value"
-        v-bind="{
-          placeholder,
-          autocomplete,
-          inputType,
-          inputClass,
-          isDisabled,
-          isReadonly,
-          suffix,
-          prefix,
-        }"
-        @update:modelValue="handleInput"
-        @dirty="touchedEvent"/>
-    </xfds-form-group>
-  </xfds-validate>
+        placeholder,
+        autocomplete,
+        inputType,
+        inputClass,
+        isDisabled,
+        isReadonly,
+        suffix,
+        prefix,
+      }"
+      @update:modelValue="handleInput"
+      @dirty="touchedEvent"/>
+  </xfds-form-group>
 </template>
 
 <script setup lang="ts">
@@ -63,10 +56,6 @@ const dirty = ref(false);
 
 const touchedEvent = () => {
   dirty.value = true;
-};
-
-const validEvent = (isValid: boolean) => {
-  emit('valid', isValid);
 };
 
 const handleInput = () => emit('update:modelValue', value.value);

--- a/src/components/extra/xfds-form-input.vue
+++ b/src/components/extra/xfds-form-input.vue
@@ -1,40 +1,33 @@
 <template>
-  <xfds-validate
-    :modelValue="value"
-    :validations="validations"
-    #default="{ isValid, errorMessage }"
-    :dirty="dirty"
-    @valid="validEvent">
-    <xfds-form-group
+  <xfds-form-group
+    v-bind="{
+      label,
+      hint,
+      tooltip,
+      isValid,
+      errorMessage,
+    }">
+    <fds-input
+      v-model="value"
       v-bind="{
-        label,
-        hint,
-        tooltip,
-        isValid,
-        errorMessage,
-      }">
-      <fds-input
-        v-model="value"
-        v-bind="{
-          placeholder,
-          autocomplete,
-          inputType,
-          inputClass,
-          isDisabled,
-          isReadonly,
-          suffix,
-          prefix,
-        }"
-        @update:modelValue="handleInput"
-        @dirty="touchedEvent">
-        <template
-          #button
-          v-if="$slots.button">
-          <slot name="button" />
-        </template>
-      </fds-input>
-    </xfds-form-group>
-  </xfds-validate>
+        placeholder,
+        autocomplete,
+        inputType,
+        inputClass,
+        isDisabled,
+        isReadonly,
+        suffix,
+        prefix,
+      }"
+      @update:modelValue="handleInput"
+      @dirty="touchedEvent">
+      <template
+        #button
+        v-if="$slots.button">
+        <slot name="button" />
+      </template>
+    </fds-input>
+  </xfds-form-group>
 </template>
 
 <script setup lang="ts">
@@ -68,10 +61,7 @@ const dirty = ref(false);
 
 const touchedEvent = () => {
   dirty.value = true;
-};
-
-const validEvent = (isValid: boolean) => {
-  emit('valid', isValid);
+  emit('dirty', true);
 };
 
 const handleInput = () => emit('update:modelValue', value.value);

--- a/src/components/extra/xfds-form-radio.vue
+++ b/src/components/extra/xfds-form-radio.vue
@@ -1,36 +1,29 @@
 <template>
-  <xfds-validate
-    :modelValue="value"
-    :validations="validations"
-    #default="{ isValid, errorMessage }"
-    :dirty="dirty"
-    @valid="validEvent">
-    <xfds-form-group
-      v-bind="{
-        label,
-        hint,
-        tooltip,
-        isValid,
-        errorMessage,
-      }">
-      <fds-radio
-        :list="options"
-        v-model="value"
-        @update:modelValue="handleInput"
-        @dirty="touchedEvent">
-        <slot />
-      </fds-radio>
-    </xfds-form-group>
-  </xfds-validate>
+  <xfds-form-group
+    v-bind="{
+      label,
+      hint,
+      tooltip,
+      isValid,
+      errorMessage,
+    }">
+    <fds-radio
+      :list="options"
+      v-model="value"
+      @update:modelValue="handleInput"
+      @dirty="touchedEvent">
+      <slot />
+    </fds-radio>
+  </xfds-form-group>
 </template>
 
 <script setup lang="ts">
 import {
   defineEmits, defineProps, PropType, ref, watch,
 } from 'vue';
-import xfdsFormGroupProps from '@/props/fds-form.props';
-import fdsInputProps from '@/props/fds-input.props';
 import { FdsOptionItem } from '@/model/fds.model';
+import fdsInputProps from '@/props/fds-input.props';
+import xfdsFormGroupProps from '@/props/fds-form.props';
 
 const props = defineProps({
   ...fdsInputProps,
@@ -51,10 +44,6 @@ const dirty = ref(false);
 
 const touchedEvent = () => {
   dirty.value = true;
-};
-
-const validEvent = (isValid: boolean) => {
-  emit('valid', isValid);
 };
 
 const handleInput = () => emit('update:modelValue', value.value);

--- a/src/components/extra/xfds-form-textarea.vue
+++ b/src/components/extra/xfds-form-textarea.vue
@@ -1,31 +1,24 @@
 <template>
-  <xfds-validate
-    :modelValue="value"
-    :validations="validations"
-    #default="{ isValid, errorMessage }"
-    :dirty="dirty"
-    @valid="validEvent">
-    <xfds-form-group
-      v-bind="{
-        label,
-        hint,
-        tooltip,
-        isValid,
-        errorMessage,
-      }">
-      <fds-textarea
-        v-model="value"
-        :placeholder="placeholder"
-        :max-length="maxLength"
-        :inputClass="inputClass"
-        :rowlength="rowlength"
-        :rows="rows"
-        :disabled="isDisabled"
-        :readonly="isReadonly"
-        @update:modelValue="handleInput"
-        @dirty="touchedEvent"></fds-textarea>
-    </xfds-form-group>
-  </xfds-validate>
+  <xfds-form-group
+    v-bind="{
+      label,
+      hint,
+      tooltip,
+      isValid,
+      errorMessage,
+    }">
+    <fds-textarea
+      v-model="value"
+      :placeholder="placeholder"
+      :max-length="maxLength"
+      :inputClass="inputClass"
+      :rowlength="rowlength"
+      :rows="rows"
+      :disabled="isDisabled"
+      :readonly="isReadonly"
+      @update:modelValue="handleInput"
+      @dirty="touchedEvent"></fds-textarea>
+  </xfds-form-group>
 </template>
 
 <script setup lang="ts">
@@ -47,10 +40,6 @@ const dirty = ref(false);
 
 const touchedEvent = () => {
   dirty.value = true;
-};
-
-const validEvent = (isValid: boolean) => {
-  emit('valid', isValid);
 };
 
 const handleInput = () => emit('update:modelValue', value.value);

--- a/src/components/fds-dropdown.vue
+++ b/src/components/fds-dropdown.vue
@@ -1,13 +1,14 @@
 <template>
   <select
     class="form-select"
+    :class="{ dirty: dirty }"
     :disabled="isDisabled"
     :name="formid"
     ref="refElement"
     :id="formid"
     v-bind="refValue"
     @change="onInput"
-    @blur="$emit('dirty', true)">
+    @blur="onDirty">
     <slot />
   </select>
 </template>
@@ -41,9 +42,14 @@ const emit = defineEmits(['update:modelValue', 'dirty', 'change']);
 
 const refValue = ref(props.modelValue);
 const refElement = ref(null);
+const dirty = ref(false);
 const { formid } = getFormId(props.id, true);
 
 const onInput = (event: Event) => emit('update:modelValue', (event?.target as HTMLInputElement).value);
+const onDirty = () => {
+  dirty.value = true;
+  emit('dirty', true);
+};
 
 onMounted(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/fds-fejlmeddelelse.vue
+++ b/src/components/fds-fejlmeddelelse.vue
@@ -1,9 +1,25 @@
 <template>
-  <div class="form-error-message">
-    <slot />
+  <div
+    class="form-error-message"
+    v-if="showError">
+    <slot>
+      {{ compErrorMessage }}
+    </slot>
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import {
+  computed, inject, ref, useSlots,
+} from 'vue';
+
+const slots = useSlots();
+
+const injErrorMessage = ref<string | null>(inject('provideErrorMessage', null));
+const compErrorMessage = computed(() => injErrorMessage.value);
+const showError = computed(() => {
+  return slots.default || compErrorMessage;
+});
+</script>
 
 <style scoped lang="scss"></style>

--- a/src/components/fds-formgroup.vue
+++ b/src/components/fds-formgroup.vue
@@ -2,13 +2,15 @@
   <div
     class="form-group"
     :key="formid"
-    :class="{ 'form-error': isValid === false }">
+    :class="{ 'form-error': compValid === false }">
     <slot :formid="formid" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { defineProps, provide } from 'vue';
+import {
+  computed, defineProps, inject, provide, ref,
+} from 'vue';
 import getFormId from '@/composable/formId';
 
 const props = defineProps({
@@ -32,6 +34,10 @@ const { formid } = getFormId(props.id, true);
  * eg. label for input element
  */
 provide('formid', formid);
+
+const injIsValid = ref<boolean | null>(inject('provideIsValid', null));
+
+const compValid = computed(() => injIsValid.value ?? props.isValid);
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/fds-formgroup.vue
+++ b/src/components/fds-formgroup.vue
@@ -8,8 +8,8 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, provide, ref } from 'vue';
-import { v4 as uuidv4 } from 'uuid';
+import { defineProps, provide } from 'vue';
+import getFormId from '@/composable/formId';
 
 const props = defineProps({
   id: {
@@ -26,7 +26,7 @@ const props = defineProps({
  * Form id der bruges i slots
  * eg. label for input element
  */
-const formid = ref(props.id ?? uuidv4());
+const { formid } = getFormId(props.id, true);
 /**
  * Provide for underliggende elementer
  * eg. label for input element

--- a/src/components/fds-tooltip.vue
+++ b/src/components/fds-tooltip.vue
@@ -31,7 +31,7 @@ const slots = useSlots();
 const slotContent = computed(() => {
   try {
     if (slots.default && slotText.value) {
-      return (slotText.value as unknown as HTMLElement).innerHTML ?? 'asdas';
+      return (slotText.value as unknown as HTMLElement).innerHTML ?? '';
     }
   } catch {
     return '';

--- a/src/composable/formId.ts
+++ b/src/composable/formId.ts
@@ -1,6 +1,12 @@
 import { computed, inject, ref } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
 
+/**
+ * Composable for getting formId if any
+ * @param localId : eg. props.Id
+ * @param autogenId : if true new id will be generated
+ * @returns
+ */
 export default function getFormId (localId: string | undefined, autogenId = false) {
   const injFormid = ref(inject('formid', null) ?? localId);
   const autoId = `fid_${uuidv4().replaceAll('-', '')}`;

--- a/src/dev_components/DevContent.vue
+++ b/src/dev_components/DevContent.vue
@@ -61,12 +61,21 @@
       <div>
         <h2>Eksempel på Form komponent (simpel brug)</h2>
 
+        <xfds-validate
+          :modelValue="txtAdresseValidering"
+          :validations="[hasContent, charactersMinLength(10)]">
+          <xfds-form-input
+            label="Adresse (m. Validering)"
+            hint="Angiv gyldig adresse"
+            tooltip="Input tooltip"
+            v-model="txtAdresseValidering"/>
+        </xfds-validate>
+
         <xfds-form-input
           label="Adresse"
           hint="Angiv gyldig adresse"
           tooltip="Input tooltip"
-          v-model="txtAdresse"
-          :validations="[hasContent, charactersMinLength(10)]"/>
+          v-model="txtAdresse"/>
 
         <xfds-form-input-number
           label="Antal kasser"
@@ -1270,7 +1279,9 @@ const txtEfternavn = ref('');
 const txtBegrundelse = ref('');
 const noBeloeb = ref(0);
 const txtAdresse = ref('');
+const txtAdresseValidering = ref('');
 const kasser = ref(0);
+const kasserValidering = ref(0);
 const txtMobil = ref('23232323');
 const txtBeskrivelse = ref('');
 const oneChecked = ref(false);

--- a/src/dev_components/DevContent.vue
+++ b/src/dev_components/DevContent.vue
@@ -24,7 +24,7 @@
           :validations="[hasContent, charactersMinLength(10)]"
           #default="{ isValid, errorMessage }">
           <fds-formgroup :is-valid="isValid">
-            <fds-label> Efternavn </fds-label>
+            <fds-label> Efternavn (m. validering) </fds-label>
             <fds-fejlmeddelelse v-if="!isValid">
               {{ errorMessage }}
             </fds-fejlmeddelelse>
@@ -35,13 +35,10 @@
 
         <xfds-validate
           :modelValue="noBeloeb"
-          :validations="[numberMax(500)]"
-          #default="{ isValid, errorMessage }">
-          <fds-formgroup :is-valid="isValid">
-            <fds-label> Beløb i kr. </fds-label>
-            <fds-fejlmeddelelse v-if="!isValid">
-              {{ errorMessage }}
-            </fds-fejlmeddelelse>
+          :validations="[numberMax(500)]">
+          <fds-formgroup>
+            <fds-label> Beløb i kr. (m. validering) </fds-label>
+            <fds-fejlmeddelelse />
             <fds-hint>Indtast efternavn</fds-hint>
             <fds-input-number
               v-model="noBeloeb"
@@ -59,7 +56,7 @@
       <hr class="my-6" />
 
       <div>
-        <h2>Eksempel på Form komponent (simpel brug)</h2>
+        <h2>Extra komponent</h2>
 
         <xfds-validate
           :modelValue="txtAdresseValidering"
@@ -105,24 +102,33 @@
           v-model="txtBeskrivelse"
           :validations="[hasContent, charactersMinLength(10)]"/>
 
-        <xfds-form-checkbox-list
-          label="Checkbox form"
-          :validations="[arrayHasItems]"
-          v-model="checkboxListForm"/>
+        <xfds-validate
+          :modelValue="checkboxListForm"
+          :validations="[arrayHasItems]">
+          <xfds-form-checkbox-list
+            label="Checkbox form"
+            v-model="checkboxListForm" />
+        </xfds-validate>
 
-        <xfds-form-dropdown
-          label="Dropdown form"
-          :validations="[hasContent]"
-          :options="dropdownOptions"
-          v-model="dropdownValForm">
-        </xfds-form-dropdown>
+        <xfds-validate
+          :modelValue="dropdownValForm"
+          :validations="[hasContent]">
+          <xfds-form-dropdown
+            label="Dropdown form"
+            :options="dropdownOptions"
+            v-model="dropdownValForm">
+          </xfds-form-dropdown>
+        </xfds-validate>
 
-        <xfds-form-radio
-          label="Radio form"
-          :validations="[hasContent]"
-          :options="radioOptions"
-          v-model="radioValForm">
-        </xfds-form-radio>
+        <xfds-validate
+          :modelValue="radioValForm"
+          :validations="[hasContent]">
+          <xfds-form-radio
+            label="Radio form"
+            :options="radioOptions"
+            v-model="radioValForm">
+          </xfds-form-radio>
+        </xfds-validate>
 
         <fds-pre :json="{ radioValForm }" />
 

--- a/src/main_plugin.ts
+++ b/src/main_plugin.ts
@@ -163,7 +163,9 @@ function install (app: App): void {
   app.component('xfds-validate', XFdsValidate);
   app.component('xfds-form-group', XFdsFormGroup);
   app.component('xfds-form-input', XFdsFormInput);
+
   app.component('xfds-form-input-number', XFdsFormInputNumber);
+
   app.component('xfds-form-textarea', XFdsFormTextarea);
   app.component('xfds-form-radio', XFdsFormRadio);
   app.component('xfds-form-dropdown', XFdsFormDropdown);

--- a/src/props/fds-form-validate.props.ts
+++ b/src/props/fds-form-validate.props.ts
@@ -1,0 +1,10 @@
+/**
+ * Comon props for Extra FDS Form Validate
+ */
+const xfdsFormValidateProps = {
+  validations: {
+    type: Array as () => Array<(x?: unknown) => string | null>,
+    default: null,
+  },
+};
+export default xfdsFormValidateProps;

--- a/src/props/fds-form.props.ts
+++ b/src/props/fds-form.props.ts
@@ -1,11 +1,7 @@
 /**
- * Comon props for FDS Textarea
+ * Comon props for Extra FDS Form group
  */
 const xfdsFormGroupProps = {
-  validations: {
-    type: Array as () => Array<(x?: unknown) => string | null>,
-    default: null,
-  },
   label: {
     type: String,
     default: '',

--- a/src/props/fds-input.props.ts
+++ b/src/props/fds-input.props.ts
@@ -1,5 +1,5 @@
 /**
- * Comon props for FDS Textarea
+ * Comon props for FDS unput
  */
 const fdsInputProps = {
   id: {


### PR DESCRIPTION
# 0.3.7

- Refak af xfds-validate
- Refak af xfds form komponenter

Validering er udskilt fra xfds form komponenter, dvs den skal kaldes seperat:

```
<xfds-validate :modelValue="user.adress" :validations="[hasContent, charactersMinLength(10)]">
  <xfds-form-input
    label="Adresse"
    hint="Angiv gyldig adresse"
    tooltip="Input tooltip"
    input-type="street-address"
    autocomplete="street-address"
    placeholder="e.g: Jarlsvej 23"
    v-model="user.adress"
  />
</xfds-validate>

// eller

<xfds-validate :modelValue="user.name" :validations="[hasContent, charactersMinLength(10)]">
  <fds-input v-model="user.name" />
</xfds-validate>
```

Som udgangspunkt vil xfds-validate selv prøve at lytte på `input|select` `blur` og begynde at validere herefter, man kan også slå dette fra `useAutoDirty=false` og selv angive `dirty`.
