### PR TITLE
fds-cookiemeddelelse

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,27 @@
 https://github.com/whitewillow/dkfds-vue3/issues
 
 
+
+# 0.3.8
+
+- fds-cookiemeddelelse
+
+Simpel cookiemeddelelse, giver kun styling for cookiemeddelelsen, ikke den tekniske implementering af cookiemeddelelsen.
+
+Du skal selv tilpasse indholdet i meddelelsen, så den overholder gældende lovgivning og stemmer overens med din løsnings specifikke anvendelse af cookies.
+
+
+```
+<fds-cookiemeddelelse 
+  @accepter="cookieAccept = $event"
+  header="Fortæl os om du accepterer cookies">
+  <p class="mt-0" id="cookie-message-text">
+    Vi indsamler statistik ved hjælp af cookies. Alle indsamlede data anonymiseres.
+    <a href="#"> Læs mere om vores brug af cookies. </a>
+  </p>
+</fds-cookiemeddelelse>
+```
+
 # 0.3.7
 
 - Refak af xfds-validate

--- a/dokumentation/WIP.md
+++ b/dokumentation/WIP.md
@@ -74,7 +74,6 @@ Og gennemføre alm. installation process for DKFDS-Vue3
   - Headers
   - Footers
   - Brødkrumme
-  - Cookiemeddelelse - LAVES IKKE
   - Tabeller - LAVES IKKE
 - Gennemgang af komponent navngivning
 - Gennemgang af komponent properties

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "core-js": "^3.8.3",
     "dkfds": "^8.2.0",
-    "dkfds-vue3": "0.3.7",
+    "dkfds-vue3": "0.3.8",
     "vue": "^3.2.39",
     "vue-router": "^4.0.3",
     "vuex": "^4.0.0"

--- a/example/src/views/Komponenter/CookieExample.vue
+++ b/example/src/views/Komponenter/CookieExample.vue
@@ -1,10 +1,106 @@
 <template>
   <section>
-    <fds-alert variant="warning" header="Vil ikke blive udviklet" canClose>
-      Dette komponent vil ikke blive udviklet.
-      <p>Det anbefales at bruge egen komponent eller npm modul</p>
+    <fds-alert variant="info" header="Under udvikling" canClose
+      >Cookiemeddelelse er stadig under udvikling, mindre ændringer kan forkomme
     </fds-alert>
+    <fds-component-preview header="Eksempel">
+      <fds-cookiemeddelelse @accepter="cookieAccept = $event" class="example_relative">
+        <template #header>
+          <div class="h3 mt-0 mb-3" id="cookie-message-heading">
+            Fortæl os om du accepterer cookies
+          </div>
+        </template>
+        <p class="mt-0" id="cookie-message-text">
+          Vi indsamler statistik ved hjælp af cookies. Alle indsamlede data anonymiseres.
+          <a href="#"> Læs mere om vores brug af cookies. </a>
+        </p>
+      </fds-cookiemeddelelse>
+
+      <fds-pre header="Cookimeddelelse" :json="{ cookieAccept }" />
+
+      <template #description>
+        <p class="italic">
+          Koden indsættes under body og før header. Gør man brug af skip link, skal skip-link
+          indsættes efter cookiemeddelelsen.
+        </p>
+        <p class="italic">
+          Bemærk at DKFDS-Vue3 på nuværende tidspunkt kun leverer HTML og CSS til denne komponent.
+          Funktionaliteten skal man derfor selv håndtere.
+        </p>
+        <p class="italic">
+          Læs mere på designsystem for vejledning:
+          <a href="https://designsystem.dk/komponenter/cookiemeddelelse/">Cookiemeddelelse</a>
+        </p>
+      </template>
+      <template #code>
+        <pre v-text="code"></pre>
+      </template>
+    </fds-component-preview>
   </section>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const cookieAccept = ref<boolean | null>(null);
+
+const code = `
+<fds-cookiemeddelelse @accepter="cookieAccept = $event">
+  <template #header>
+    <div class="h3 mt-0 mb-3" id="cookie-message-heading">
+      Fortæl os om du accepterer cookies
+    </div>
+  </template>
+  <p class="mt-0" id="cookie-message-text">
+    Vi indsamler statistik ved hjælp af cookies. Alle indsamlede data anonymiseres.
+    <a href="#"> Læs mere om vores brug af cookies. </a>
+  </p>
+</fds-cookiemeddelelse>
+
+// Eller
+
+<fds-cookiemeddelelse 
+  @accepter="cookieAccept = $event"
+  header="Fortæl os om du accepterer cookies">
+  <p class="mt-0" id="cookie-message-text">
+    Vi indsamler statistik ved hjælp af cookies. Alle indsamlede data anonymiseres.
+    <a href="#"> Læs mere om vores brug af cookies. </a>
+  </p>
+</fds-cookiemeddelelse>
+
+// Eller egne knapper
+
+<fds-cookiemeddelelse 
+  @accepter="cookieAccept = $event"
+  header="Fortæl os om du accepterer cookies">
+  <p class="mt-0" id="cookie-message-text">
+    Vi indsamler statistik ved hjælp af cookies. Alle indsamlede data anonymiseres.
+    <a href="#"> Læs mere om vores brug af cookies. </a>
+  </p>
+  <template #actions>
+    <fds-button
+      variant="secondary">
+      Accepter cookies
+    </fds-button>
+    <fds-button
+      variant="secondary">
+      Nej tak til cookies
+    </fds-button>
+  </template>
+</fds-cookiemeddelelse>
+
+
+
+`;
+</script>
+
+<style lang="scss" scoped>
+.example_relative {
+  position: relative;
+  right: auto;
+  bottom: auto;
+  left: auto;
+  top: auto;
+  z-index: 1;
+}
+</style>

--- a/example/src/views/KomponenterView.vue
+++ b/example/src/views/KomponenterView.vue
@@ -56,7 +56,7 @@ const navigationList = ref<Array<FdsNavigationItem>>([
   {
     key: 'komponentcookie',
     title: 'Cookiemeddelelse',
-    icon: 'feedback',
+    icon: 'engineering',
   },
   {
     key: 'komponentdatoangivelse',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkfds-vue3",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "dist/dkfds-vue3.esm.js",
   "types": "dist/main.d.ts",
   "repository": {

--- a/src/components/fds-cookiemeddelelse.vue
+++ b/src/components/fds-cookiemeddelelse.vue
@@ -1,0 +1,75 @@
+<template>
+  <div
+    v-if="show"
+    class="cookie-container"
+    role="complementary"
+    aria-labelledby="cookie-message-heading"
+    aria-describedby="cookie-message-text">
+    <div class="cookie-message">
+      <div class="cookie-text">
+        <slot name="header">
+          <div
+            class="h3 mt-0 mb-3"
+            id="cookie-message-heading">
+            {{ header }}
+          </div>
+        </slot>
+        <slot>
+          <p
+            class="mt-0"
+            id="cookie-message-text">
+            Vi indsamler statistik ved hjælp af cookies. Alle indsamlede data anonymiseres.
+            <a href="#">
+              Læs mere om vores brug af cookies.
+            </a>
+          </p>
+        </slot>
+      </div>
+      <div class="cookie-actions">
+        <slot name="actions">
+          <ul class="inline-list">
+            <li>
+              <fds-button
+                variant="secondary"
+                @click="$emit('accepter', true)">
+                Accepter cookies
+              </fds-button>
+            </li>
+            <li class="ml-4">
+              <fds-button
+                variant="secondary"
+                @click="$emit('accepter', false)">
+                Nej tak til cookies
+              </fds-button>
+            </li>
+          </ul>
+        </slot>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ *
+ * Komponent for cookie
+ * https://designsystem.dk/kode/komponenter/cookiemeddelelse/
+ *
+ * */
+import { defineProps } from 'vue';
+
+defineProps({
+  /**
+   * Overskrift
+   * */
+  header: {
+    type: String,
+    default: 'Fortæl os om du accepterer cookies',
+  },
+
+  show: {
+    type: Boolean,
+    default: true,
+  },
+});
+</script>

--- a/src/dev_components/DevContent.vue
+++ b/src/dev_components/DevContent.vue
@@ -1,5 +1,12 @@
 <template>
   <div class="home">
+    <fds-cookiemeddelelse
+      :show="cookieAccept === null"
+      @accepter="cookieAccept = $event" />
+
+    <fds-pre
+      header="Cookimeddelelse"
+      :json="{ cookieAccept }" />
     <fds-toast-container />
 
     <div class="container pb-6">
@@ -1270,6 +1277,7 @@ const genLargeArray = computed((): Array<{ id: string; indhold: string }> => {
   }));
 });
 
+const cookieAccept = ref<boolean | null>(null);
 const showToast = ref(false);
 const datoValg = ref('2022-12-01');
 const datoValgValid = ref(true);

--- a/src/main_plugin.ts
+++ b/src/main_plugin.ts
@@ -6,6 +6,7 @@ import FdsStruktureredeListe from '@/components/fds-strukturerede-liste.vue';
 
 import FdsAlert from '@/components/fds-alert.vue';
 import FdsPre from '@/components/fds-pre.vue';
+import FdsCookiemeddelelse from '@/components/fds-cookiemeddelelse.vue';
 
 import FdsFormgroup from '@/components/fds-formgroup.vue';
 import FdsTooltip from '@/components/fds-tooltip.vue';
@@ -98,6 +99,8 @@ export * from '@/utils/file-utils';
 function install (app: App): void {
   app.component('fds-trinindikator', FdsTrinindikator);
   app.component('fds-modal', FdsModal);
+  app.component('fds-cookiemeddelelse', FdsCookiemeddelelse);
+
   app.component('fds-overflow-menu', FdsOverflowMenu);
   app.component('fds-strukturerede-liste', FdsStruktureredeListe);
   app.component('fds-dato-angivelse', FdsDatoAngivelse);
@@ -179,6 +182,7 @@ function install (app: App): void {
 export {
   FdsAlert,
   FdsModal,
+  FdsCookiemeddelelse,
   FdsOverflowMenu,
   FdsToastContainer,
   FdsToast,


### PR DESCRIPTION
Simpel cookiemeddelelse, giver kun styling for cookiemeddelelsen, ikke den tekniske implementering af cookiemeddelelsen.

Du skal selv tilpasse indholdet i meddelelsen, så den overholder gældende lovgivning og stemmer overens med din løsnings specifikke anvendelse af cookies.