### PR TITLE
WIP - Prototype af DOM-enhancments (primært a11y) på form-group

### DIFF
--- a/packages/core/src/components/fds-formgroup.vue
+++ b/packages/core/src/components/fds-formgroup.vue
@@ -1,15 +1,20 @@
 <template>
   <div
+    ref="formGroupElement"
     :key="formid"
     class="form-group"
-    :class="{ 'form-error': compValid === false }">
+    :class="{ 'form-error': compValid === false }"
+  >
     <slot :formid="formid" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, defineProps, inject, provide, ref } from 'vue';
+import { computed, defineProps, inject, onMounted, onUpdated, provide, ref } from 'vue';
 import { formId } from 'dkfds-vue3-utils';
+import { enhanceFormGroupDOM } from '../enhance-form-group-dom';
+
+const formGroupElement = ref<HTMLElement>();
 
 const props = defineProps({
   id: {
@@ -20,6 +25,16 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+});
+
+onMounted(() => {
+  console.log('Mounted formgroup');
+  enhanceFormGroupDOM(formGroupElement.value, compValid.value);
+});
+
+onUpdated(() => {
+  console.log('Updated formgroup');
+  enhanceFormGroupDOM(formGroupElement.value, compValid.value);
 });
 
 /**

--- a/packages/core/src/enhance-form-group-dom.ts
+++ b/packages/core/src/enhance-form-group-dom.ts
@@ -1,0 +1,34 @@
+export function enhanceFormGroupDOM(formFieldElement: HTMLElement, isControlValid : boolean): void {
+  const controlElement = formFieldElement.querySelector(".form-input");
+  console.log("control", controlElement);
+  controlElement.id = controlElement.id || window.crypto.randomUUID();
+  controlElement.setAttribute("aria-invalid", String(!isControlValid));
+
+  const labelElement = formFieldElement.querySelector(".form-label");
+  console.log("label", labelElement);
+  labelElement.setAttribute("for", controlElement.id);
+
+  const hintElement = formFieldElement.querySelector(".form-hint");
+  console.log("hint", hintElement);
+  if (hintElement) {
+    hintElement.id = hintElement.id || window.crypto.randomUUID();
+    controlElement.setAttribute("aria-describedby", hintElement.id);
+    //TODO append til describedby istedet, med mindre den allerede er der
+  }
+
+  const errorMessageElement = formFieldElement.querySelector(".form-error-message");
+  console.log("error message", errorMessageElement);
+  if (errorMessageElement) {
+    errorMessageElement.id = errorMessageElement.id || window.crypto.randomUUID();
+    controlElement.setAttribute("aria-errormessage", errorMessageElement.id);
+    //TODO append til errormessage istedet, med mindre den allerede er der
+    errorMessageElement.setAttribute("aria-live", "polite");
+    errorMessageElement.setAttribute("aria-atomic", "true");
+  }
+
+  //TODO enhance tooltip
+  //TODO enhange prefix
+  //TODO enhange suffix
+  //TODO enhange search-button
+  //TODO enhance input-limit
+}


### PR DESCRIPTION
Et eksperiment hvor der i fds-formgroup laves nogle DOM-manipulationer der sikre følgende:
- Label er linked til control (control har "id" og label har "for")
- Hint er linked til control (hint har "id" og control har "aria-describedby")
- Error-message er linked til control (error-message har "id" og control har "aria-errormessage")
- Error-message er A11Y-friendly (error-message har "aria-live=potite" og "aria-atomic=true")
- Control er A11Y-friendly omkring validity (control har "aria-invalid")